### PR TITLE
Add button to create Numbered List in Playground (Issue #7)

### DIFF
--- a/Playground/LexicalPlayground/ToolbarPlugin.swift
+++ b/Playground/LexicalPlayground/ToolbarPlugin.swift
@@ -211,6 +211,9 @@ public class ToolbarPlugin: Plugin {
       }),
       UIAction(title: "Bulleted List", image: UIImage(systemName: "list.bullet"), handler: { (_) in
         self.editor?.dispatchCommand(type: .insertUnorderedList)
+      }),
+      UIAction(title: "Numbered List", image: UIImage(systemName: "list.number"), handler: { (_) in
+        self.editor?.dispatchCommand(type: .insertOrderedList)
       })
     ]
   }

--- a/Plugins/LexicalListPlugin/LexicalListPlugin/ListPlugin.swift
+++ b/Plugins/LexicalListPlugin/LexicalListPlugin/ListPlugin.swift
@@ -11,6 +11,7 @@ import UIKit
 
 extension CommandType {
   public static let insertUnorderedList = CommandType(rawValue: "insertUnorderedList")
+  public static let insertOrderedList = CommandType(rawValue: "insertOrderedList")
   public static let removeList = CommandType(rawValue: "removeList")
 }
 
@@ -28,6 +29,12 @@ open class ListPlugin: Plugin {
       _ = editor.registerCommand(type: .insertUnorderedList, listener: { [weak editor] payload in
         guard let editor else { return false }
         try? insertList(editor: editor, listType: .bullet)
+        return true
+      })
+
+      _ = editor.registerCommand(type: .insertOrderedList, listener: { [weak editor] payload in
+        guard let editor else { return false }
+        try? insertList(editor: editor, listType: .number)
         return true
       })
 


### PR DESCRIPTION
Summary:
Add button to create Numbered List in Playground as part of Issue #7

Numbered List Button

<img width="315" alt="Screenshot 2023-04-06 at 1 40 30 PM" src="https://user-images.githubusercontent.com/46061053/230490393-517fab7f-8afe-441f-8f1b-3b5a763136a1.png">


Numbered List

<img width="312" alt="Screenshot 2023-04-06 at 1 41 58 PM" src="https://user-images.githubusercontent.com/46061053/230490508-bcfa663a-8419-4ed0-85eb-31d32445d539.png">
