### PR TITLE
LexicalViewDelegate's textViewShouldChangeText updated to return Bool

### DIFF
--- a/Lexical/LexicalView/LexicalView.swift
+++ b/Lexical/LexicalView/LexicalView.swift
@@ -17,7 +17,7 @@ import UIKit
 public protocol LexicalViewDelegate: NSObjectProtocol {
   func textViewDidBeginEditing(textView: LexicalView)
   func textViewDidEndEditing(textView: LexicalView)
-  func textViewShouldChangeText(_ textView: LexicalView, range: NSRange, replacementText text: String)
+  func textViewShouldChangeText(_ textView: LexicalView, range: NSRange, replacementText text: String) -> Bool
   func textView(_ textView: LexicalView, shouldInteractWith URL: URL, in selection: RangeSelection?, interaction: UITextItemInteraction) -> Bool
 }
 
@@ -506,7 +506,11 @@ extension LexicalView: LexicalTextViewDelegate {
     delegate?.textViewDidEndEditing(textView: self)
   }
 
-  func textViewShouldChangeText(_ textView: UITextView, range: NSRange, replacementText text: String) {
-    delegate?.textViewShouldChangeText(self, range: range, replacementText: text)
+  func textViewShouldChangeText(_ textView: UITextView, range: NSRange, replacementText text: String) -> Bool {
+    if let delegate = delegate {
+      return delegate.textViewShouldChangeText(self, range: range, replacementText: text)
+    }
+    
+    return true
   }
 }

--- a/Lexical/LexicalView/LexicalView.swift
+++ b/Lexical/LexicalView/LexicalView.swift
@@ -507,7 +507,7 @@ extension LexicalView: LexicalTextViewDelegate {
   }
 
   func textViewShouldChangeText(_ textView: UITextView, range: NSRange, replacementText text: String) -> Bool {
-    if let delegate = delegate {
+    if let delegate {
       return delegate.textViewShouldChangeText(self, range: range, replacementText: text)
     }
     

--- a/Lexical/TextView/TextView.swift
+++ b/Lexical/TextView/TextView.swift
@@ -11,7 +11,7 @@ import UIKit
 protocol LexicalTextViewDelegate: NSObjectProtocol {
   func textViewDidBeginEditing(textView: TextView)
   func textViewDidEndEditing(textView: TextView)
-  func textViewShouldChangeText(_ textView: UITextView, range: NSRange, replacementText text: String)
+  func textViewShouldChangeText(_ textView: UITextView, range: NSRange, replacementText text: String) -> Bool
   func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool
 }
 
@@ -399,7 +399,9 @@ extension TextView: UITextViewDelegate {
 
   public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
     hidePlaceholderLabel()
-    lexicalDelegate?.textViewShouldChangeText(self, range: range, replacementText: text)
+    if let lexicalDelegate = lexicalDelegate {
+      return lexicalDelegate.textViewShouldChangeText(self, range: range, replacementText: text)
+    }
 
     return true
   }

--- a/Lexical/TextView/TextView.swift
+++ b/Lexical/TextView/TextView.swift
@@ -399,7 +399,7 @@ extension TextView: UITextViewDelegate {
 
   public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
     hidePlaceholderLabel()
-    if let lexicalDelegate = lexicalDelegate {
+    if let lexicalDelegate {
       return lexicalDelegate.textViewShouldChangeText(self, range: range, replacementText: text)
     }
 


### PR DESCRIPTION
The current implementation does not allow the `LexicalView`'s delegate to refuse text changes in `textViewShouldChangeText`. This PR remediates that by updating the return type of the `LexicalViewDelegate` protocol from Void to `Bool` and making the necessary changes in the `LexicalView` extension which implements `LexicalViewDelegate`.

Tests have been run successfully.