### PR TITLE
Memory leak fixes

### DIFF
--- a/Lexical/Core/Events.swift
+++ b/Lexical/Core/Events.swift
@@ -400,8 +400,8 @@ public func registerRichText(editor: Editor) {
     return true
   })
 
-  _ = editor.registerCommand(type: .updatePlaceholderVisibility) { payload in
-    editor.frontend?.showPlaceholderText()
+  _ = editor.registerCommand(type: .updatePlaceholderVisibility) { [weak editor] payload in
+    editor?.frontend?.showPlaceholderText()
     return true
   }
 }

--- a/Playground/LexicalPlayground/ToolbarPlugin.swift
+++ b/Playground/LexicalPlayground/ToolbarPlugin.swift
@@ -21,7 +21,7 @@ public class ToolbarPlugin: Plugin {
   weak var viewControllerForPresentation: UIViewController?
   weak var historyPlugin: EditorHistoryPlugin?
 
-  init(viewControllerForPresentation: UIViewController, historyPlugin: EditorHistoryPlugin) {
+  init(viewControllerForPresentation: UIViewController, historyPlugin: EditorHistoryPlugin?) {
     self._toolbar = UIToolbar()
     self.historyPlugin = historyPlugin
     self.viewControllerForPresentation = viewControllerForPresentation

--- a/Plugins/LexicalLinkPlugin/LexicalLinkPlugin/LinkPlugin.swift
+++ b/Plugins/LexicalLinkPlugin/LexicalLinkPlugin/LinkPlugin.swift
@@ -28,7 +28,7 @@ open class LinkPlugin: Plugin {
   public init() {}
 
   weak var editor: Editor?
-  public var lexicalView: LexicalView?
+  public weak var lexicalView: LexicalView?
 
   public func setUp(editor: Editor) {
     self.editor = editor


### PR DESCRIPTION
This fixes 2/3 memory leaks in the Editor and makes the history plugin optional for the toolbar.

The third source of memory leaks is the History Plugin if anybody wants to take that on to fix.

This partially fixes issues referenced in: https://github.com/facebook/lexical-ios/issues/39