### PR TITLE
Use weak editor in Events - to fix a memory leak

### DIFF
--- a/Lexical/Core/Events.swift
+++ b/Lexical/Core/Events.swift
@@ -400,8 +400,8 @@ public func registerRichText(editor: Editor) {
     return true
   })
 
-  _ = editor.registerCommand(type: .updatePlaceholderVisibility) { payload in
-    editor.frontend?.showPlaceholderText()
+  _ = editor.registerCommand(type: .updatePlaceholderVisibility) { [weak editor] payload in
+    editor?.frontend?.showPlaceholderText()
     return true
   }
 }


### PR DESCRIPTION
Use weak editor in Events - to fix a memory leak

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/lexical-ios/pull/41).
* #43
* #40
* #42
* __->__ #41