### PR TITLE
Make LexicalView in LinkPlugin weak - to avoid memory leak caused by circular reference LinkPlugin -> LexicalView -> Edi

### DIFF
--- a/Lexical/Core/Events.swift
+++ b/Lexical/Core/Events.swift
@@ -400,8 +400,8 @@ public func registerRichText(editor: Editor) {
     return true
   })
 
-  _ = editor.registerCommand(type: .updatePlaceholderVisibility) { payload in
-    editor.frontend?.showPlaceholderText()
+  _ = editor.registerCommand(type: .updatePlaceholderVisibility) { [weak editor] payload in
+    editor?.frontend?.showPlaceholderText()
     return true
   }
 }

--- a/Plugins/LexicalLinkPlugin/LexicalLinkPlugin/LinkPlugin.swift
+++ b/Plugins/LexicalLinkPlugin/LexicalLinkPlugin/LinkPlugin.swift
@@ -28,7 +28,7 @@ open class LinkPlugin: Plugin {
   public init() {}
 
   weak var editor: Editor?
-  public var lexicalView: LexicalView?
+  public weak var lexicalView: LexicalView?
 
   public func setUp(editor: Editor) {
     self.editor = editor


### PR DESCRIPTION
Make LexicalView in LinkPlugin weak - to avoid memory leak caused by circular reference LinkPlugin -> LexicalView -> Editor -> Plugins[] -> LinkPlugin
