### PR TITLE
Fix index out of bound on range selection

### DIFF
--- a/Lexical/Core/Selection/RangeSelection.swift
+++ b/Lexical/Core/Selection/RangeSelection.swift
@@ -1159,7 +1159,7 @@ public class RangeSelection: BaseSelection {
         if startOffset != 0 {
           // the entire first node isn't selected, so split it
           let splitNodes = try textNode.splitText(splitOffsets: [startOffset])
-          if splitNodes.count >= 1 {
+          if splitNodes.count > 1 {
             textNode = splitNodes[1]
           }
 


### PR DESCRIPTION
This addresses a crash when creating links (also mentioned in https://github.com/facebook/lexical-ios/issues/35)