### PR TITLE
LexicalMarkdownPlugin: say hello to markdown exports

### DIFF
--- a/Lexical/Core/Selection/RangeSelection.swift
+++ b/Lexical/Core/Selection/RangeSelection.swift
@@ -1159,7 +1159,7 @@ public class RangeSelection: BaseSelection {
         if startOffset != 0 {
           // the entire first node isn't selected, so split it
           let splitNodes = try textNode.splitText(splitOffsets: [startOffset])
-          if splitNodes.count >= 1 {
+          if splitNodes.count > 1 {
             textNode = splitNodes[1]
           }
 

--- a/Package.swift
+++ b/Package.swift
@@ -42,6 +42,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.6.0"),
+    .package(url: "https://github.com/apple/swift-markdown.git", branch: "main"),
   ],
   targets: [
     .target(
@@ -109,11 +110,15 @@ let package = Package(
 
     .target(
       name: "LexicalMarkdown",
-      dependencies: ["Lexical"],
+      dependencies: ["Lexical", 
+        .product(name: "Markdown", package: "swift-markdown")
+      ],
       path: "./Plugins/LexicalMarkdown/LexicalMarkdown"),
     .testTarget(
       name: "LexicalMarkdownTests",
-      dependencies: ["Lexical", "LexicalMarkdown"],
+      dependencies: ["Lexical", "LexicalMarkdown",
+        .product(name: "Markdown", package: "swift-markdown"),
+      ],
       path: "./Plugins/LexicalMarkdown/LexicalMarkdownTests"),
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -110,7 +110,7 @@ let package = Package(
 
     .target(
       name: "LexicalMarkdown",
-      dependencies: ["Lexical", 
+      dependencies: ["Lexical", "LexicalLinkPlugin", "LexicalListPlugin",
         .product(name: "Markdown", package: "swift-markdown")
       ],
       path: "./Plugins/LexicalMarkdown/LexicalMarkdown"),

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,9 @@ let package = Package(
     .library(
       name: "EditorHistoryPlugin",
       targets: ["EditorHistoryPlugin"]),
+    .library(
+      name: "LexicalMarkdown",
+      targets: ["LexicalMarkdown"]),
   ],
   dependencies: [
     .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.6.0"),
@@ -103,5 +106,14 @@ let package = Package(
       name: "EditorHistoryPluginTests",
       dependencies: ["Lexical", "EditorHistoryPlugin"],
       path: "./Plugins/EditorHistoryPlugin/EditorHistoryPluginTests"),
+
+    .target(
+      name: "LexicalMarkdown",
+      dependencies: ["Lexical"],
+      path: "./Plugins/LexicalMarkdown/LexicalMarkdown"),
+    .testTarget(
+      name: "LexicalMarkdownTests",
+      dependencies: ["Lexical", "LexicalMarkdown"],
+      path: "./Plugins/LexicalMarkdown/LexicalMarkdownTests"),
   ]
 )

--- a/Playground/LexicalPlayground.xcodeproj/project.pbxproj
+++ b/Playground/LexicalPlayground.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		06CB47B429DE0139005AC7BD /* NodeHierarchyViewPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CB47B329DE0139005AC7BD /* NodeHierarchyViewPlugin.swift */; };
 		06F7CF942A542E4E0024CD5A /* LexicalInlineImagePlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 06F7CF932A542E4E0024CD5A /* LexicalInlineImagePlugin */; };
 		06F7CF962A545C7C0024CD5A /* lexical-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = 06F7CF952A545C7C0024CD5A /* lexical-logo.png */; };
+		3C48FEE42B04F2C5009BBFA2 /* LexicalMarkdown in Frameworks */ = {isa = PBXBuildFile; productRef = 3C48FEE32B04F2C5009BBFA2 /* LexicalMarkdown */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -45,6 +46,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0656CFA229D48391009CA08F /* LexicalListPlugin in Frameworks */,
+				3C48FEE42B04F2C5009BBFA2 /* LexicalMarkdown in Frameworks */,
 				065B5C862A22291C003A38DB /* SelectableDecoratorNode in Frameworks */,
 				069E59DB2A1EBF1700CA4296 /* LexicalHTML in Frameworks */,
 				065F9DF72A5EC1D600C95087 /* EditorHistoryPlugin in Frameworks */,
@@ -133,6 +135,7 @@
 				06F7CF932A542E4E0024CD5A /* LexicalInlineImagePlugin */,
 				065B5C852A22291C003A38DB /* SelectableDecoratorNode */,
 				065F9DF62A5EC1D600C95087 /* EditorHistoryPlugin */,
+				3C48FEE32B04F2C5009BBFA2 /* LexicalMarkdown */,
 			);
 			productName = LexicalPlayground;
 			productReference = 0656CF7529D1E438009CA08F /* LexicalPlayground.app */;
@@ -445,6 +448,10 @@
 		06F7CF932A542E4E0024CD5A /* LexicalInlineImagePlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = LexicalInlineImagePlugin;
+		};
+		3C48FEE32B04F2C5009BBFA2 /* LexicalMarkdown */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LexicalMarkdown;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Playground/LexicalPlayground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Playground/LexicalPlayground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
   "pins" : [
     {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-cmark.git",
+      "state" : {
+        "branch" : "gfm",
+        "revision" : "3bc2f3e25df0cecc5dc269f7ccae65d0f386f06a"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-markdown.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "c211079c200ce2c5f68160bf75ded005b1c945f1"
+      }
+    },
+    {
       "identity" : "swiftsoup",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",

--- a/Playground/LexicalPlayground/ExportOutputViewController.swift
+++ b/Playground/LexicalPlayground/ExportOutputViewController.swift
@@ -11,10 +11,18 @@ import LexicalListPlugin
 import LexicalMarkdown
 import UIKit
 
-internal enum OutputFormat {
+internal enum OutputFormat: CaseIterable {
   case html
   case json
   case markdown
+
+  var title: String {
+    switch self {
+    case .html: return "HTML"
+    case .json: return "JSON"
+    case .markdown: return "Markdown"
+    }
+  }
 }
 
 class ExportOutputViewController: UIViewController {

--- a/Playground/LexicalPlayground/ExportOutputViewController.swift
+++ b/Playground/LexicalPlayground/ExportOutputViewController.swift
@@ -8,11 +8,13 @@
 import Lexical
 import LexicalHTML
 import LexicalListPlugin
+import LexicalMarkdown
 import UIKit
 
 internal enum OutputFormat {
   case html
   case json
+  case markdown
 }
 
 class ExportOutputViewController: UIViewController {
@@ -25,6 +27,8 @@ class ExportOutputViewController: UIViewController {
       generateHTML(editor: editor)
     case .json:
       generateJSON(editor: editor)
+    case .markdown:
+      generateMarkdown(editor: editor)
     }
   }
 
@@ -35,6 +39,12 @@ class ExportOutputViewController: UIViewController {
   func generateHTML(editor: Editor) {
     try? editor.read {
       self.output = try generateHTMLFromNodes(editor: editor, selection: nil)
+    }
+  }
+
+  func generateMarkdown(editor: Editor) {
+    try? editor.read {
+      self.output = try LexicalMarkdown.generateMarkdown(from: editor, selection: nil)
     }
   }
 

--- a/Playground/LexicalPlayground/ExportOutputViewController.swift
+++ b/Playground/LexicalPlayground/ExportOutputViewController.swift
@@ -46,13 +46,21 @@ class ExportOutputViewController: UIViewController {
 
   func generateHTML(editor: Editor) {
     try? editor.read {
-      self.output = try generateHTMLFromNodes(editor: editor, selection: nil)
+      do {
+        self.output = try generateHTMLFromNodes(editor: editor, selection: nil)
+      } catch let error {
+        self.output = error.localizedDescription
+      }
     }
   }
 
   func generateMarkdown(editor: Editor) {
     try? editor.read {
-      self.output = try LexicalMarkdown.generateMarkdown(from: editor, selection: nil)
+      do {
+        self.output = try LexicalMarkdown.generateMarkdown(from: editor, selection: nil)
+      } catch let error {
+        self.output = error.localizedDescription
+      }
     }
   }
 
@@ -60,6 +68,8 @@ class ExportOutputViewController: UIViewController {
     let currentEditorState = editor.getEditorState()
     if let jsonString = try? currentEditorState.toJSON() {
       output = jsonString
+    } else {
+      output = "Failed to generate JSON output"
     }
   }
 

--- a/Playground/LexicalPlayground/ViewController.swift
+++ b/Playground/LexicalPlayground/ViewController.swift
@@ -117,14 +117,11 @@ class ViewController: UIViewController, UIToolbarDelegate {
   }
 
   func setUpExportMenu() {
-    let menuItems = [
-      UIAction(title: "Export HTML", handler: { [weak self] action in
-        self?.showExportScreen(.html)
-      }),
-      UIAction(title: "Export JSON", handler: { [weak self] ction in
-        self?.showExportScreen(.json)
+    let menuItems = OutputFormat.allCases.map { outputFormat in
+      UIAction(title: "Export \(outputFormat.title)", handler: { [weak self] action in
+        self?.showExportScreen(outputFormat)
       })
-    ]
+    }
     let menu = UIMenu(title: "Export as…", children: menuItems)
     let barButtonItem = UIBarButtonItem(title: "Export", style: .plain, target: nil, action: nil)
     barButtonItem.menu = menu

--- a/Plugins/LexicalMarkdown/LexicalMarkdown/LexicalMarkdown.swift
+++ b/Plugins/LexicalMarkdown/LexicalMarkdown/LexicalMarkdown.swift
@@ -1,0 +1,26 @@
+//
+//  LexicalMarkdown.swift
+//
+//
+//  Created by mani on 15/11/2023.
+//
+
+import Foundation
+import Lexical
+
+open class LexicalMarkdown: Plugin {
+  public init() {}
+
+  weak var editor: Editor?
+
+  public func setUp(editor: Editor) {
+    self.editor = editor
+  }
+
+  public func tearDown() {
+  }
+
+  public class func generateMarkdown(from editor: Editor, selection: BaseSelection?) throws -> String {
+    throw NSError(domain: "", code: 0, userInfo: [NSLocalizedFailureReasonErrorKey: "Unimplemented"])
+  }
+}

--- a/Plugins/LexicalMarkdown/LexicalMarkdown/LexicalMarkdown.swift
+++ b/Plugins/LexicalMarkdown/LexicalMarkdown/LexicalMarkdown.swift
@@ -1,11 +1,12 @@
-//
-//  LexicalMarkdown.swift
-//
-//
-//  Created by mani on 15/11/2023.
-//
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import Foundation
+import Markdown
 import Lexical
 
 open class LexicalMarkdown: Plugin {
@@ -20,7 +21,12 @@ open class LexicalMarkdown: Plugin {
   public func tearDown() {
   }
 
-  public class func generateMarkdown(from editor: Editor, selection: BaseSelection?) throws -> String {
-    throw NSError(domain: "", code: 0, userInfo: [NSLocalizedFailureReasonErrorKey: "Unimplemented"])
+  public class func generateMarkdown(from editor: Editor, 
+                                     selection: BaseSelection?) throws -> String {
+    guard let root = editor.getEditorState().getRootNode() else {
+      return ""
+    }
+
+    return Markdown.Document(root.getChildren().exportAsBlockMarkdown()).format()
   }
 }

--- a/Plugins/LexicalMarkdown/LexicalMarkdown/LexicalMarkdownUtils.swift
+++ b/Plugins/LexicalMarkdown/LexicalMarkdown/LexicalMarkdownUtils.swift
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Foundation
+import Lexical
+import Markdown
+
+extension Array where Element == Node {
+  func exportAsInlineMarkdown(indentation: Int) -> [Markdown.InlineMarkup] {
+    compactMap {
+      try? ($0 as? NodeMarkdownInlineSupport)?.exportInlineMarkdown(indentation: indentation)
+    }
+  }
+
+  func exportAsBlockMarkdown() -> [Markdown.BlockMarkup] {
+    compactMap {
+      try? ($0 as? NodeMarkdownBlockSupport)?.exportBlockMarkdown()
+    }
+  }
+}

--- a/Plugins/LexicalMarkdown/LexicalMarkdown/NodeMarkdownSupport.swift
+++ b/Plugins/LexicalMarkdown/LexicalMarkdown/NodeMarkdownSupport.swift
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Foundation
+import Lexical
+import LexicalLinkPlugin
+import LexicalListPlugin
+import Markdown
+
+private func makeIndentation(_ count: Int) -> String {
+  String(repeating: "\u{009}", count: count)
+}
+
+public protocol NodeMarkdownBlockSupport: Lexical.Node {
+  func exportBlockMarkdown() throws -> Markdown.BlockMarkup
+}
+
+public protocol NodeMarkdownInlineSupport: Lexical.Node {
+  func exportInlineMarkdown(indentation: Int) throws -> Markdown.InlineMarkup
+}
+
+extension Lexical.ParagraphNode: NodeMarkdownBlockSupport {
+  public func exportBlockMarkdown() throws -> Markdown.BlockMarkup {
+    return Markdown.Paragraph(getChildren().exportAsInlineMarkdown(indentation: getIndent()))
+  }
+}
+
+extension Lexical.TextNode: NodeMarkdownInlineSupport {
+  public func exportInlineMarkdown(indentation: Int) throws -> Markdown.InlineMarkup {
+    let format = getFormat()
+    var node: Markdown.InlineMarkup = Markdown.Text(makeIndentation(indentation) + getTextPart())
+
+    if format.code {
+      // NOTE (mani) - code must always come first
+      node = Markdown.InlineCode(makeIndentation(indentation) + getTextPart())
+    }
+
+    if format.bold {
+      node = Markdown.Strong(node)
+    }
+
+    if format.strikethrough {
+      node = Markdown.Strikethrough(node)
+    }
+
+    if format.italic {
+      // TODO (mani) - underline + italic both use Emphasis node
+      // should we create a separate node?
+      node = Markdown.Emphasis(node)
+    }
+
+    if format.underline {
+      // TODO (mani) - underline + italic both use Emphasis node
+      // should we create a separate node?
+      node = Markdown.Emphasis(node)
+    }
+
+    if format.superScript {
+      // NOTE (mani) - unsupported
+    }
+
+    if format.subScript {
+      // NOTE (mani) - unsupported
+    }
+
+    return node
+  }
+}
+
+extension LexicalListPlugin.ListNode: NodeMarkdownBlockSupport {
+  // NOTE (mani) - there are some oddities when converting lists
+  // especially when lists have sub lists.
+  // Sometimes Lexical will not realise that the top level list has been deleted
+  // and so it will look like `List -> ListItem -> List -> [ListItem]` which outputs
+  // incorrect markdown. Assume indentations are not properly supported.
+  // Also, no support for checkmarks in Lexical AFAIK.
+
+  public func exportBlockMarkdown() throws -> Markdown.BlockMarkup {
+    let children = getChildren().exportAsBlockMarkdown()
+      .compactMap { $0 as? Markdown.ListItem }
+    switch getListType() {
+    case .bullet:
+      return Markdown.UnorderedList(children)
+    case .check:
+      // TODO (mani) - how does lexical mark a checked item?
+      return Markdown.UnorderedList(children)
+    case .number:
+      var list = Markdown.OrderedList(children)
+      let start = getStart()
+      if start > 0 {
+        list.startIndex = UInt(start)
+      }
+      return list
+    }
+  }
+}
+
+extension LexicalListPlugin.ListItemNode: NodeMarkdownBlockSupport {
+  public func exportBlockMarkdown() throws -> Markdown.BlockMarkup {
+    let children: [Markdown.BlockMarkup] = getChildren().compactMap {
+      if let inline = try? ($0 as? NodeMarkdownInlineSupport)?.exportInlineMarkdown(indentation: getIndent()) {
+        return Markdown.Paragraph(inline)
+      } else {
+        return try? ($0 as? NodeMarkdownBlockSupport)?.exportBlockMarkdown()
+      }
+    }
+
+    if let parent = getParent() as? ListNode, parent.getListType() == .check {
+      // TODO (mani) - how does lexical mark a checked item?
+      return Markdown.ListItem(checkbox: nil, children)
+    } else {
+      return Markdown.ListItem(children)
+    }
+  }
+}
+
+extension LexicalLinkPlugin.LinkNode: NodeMarkdownInlineSupport {
+  public func exportInlineMarkdown(indentation: Int) throws -> Markdown.InlineMarkup {
+    Markdown.Link(destination: getURL(),
+                  getChildren()
+      .exportAsInlineMarkdown(indentation: getIndent())
+      .compactMap { $0 as? Markdown.RecurringInlineMarkup })
+  }
+}
+
+extension Lexical.CodeNode: NodeMarkdownBlockSupport {
+  public func exportBlockMarkdown() throws -> Markdown.BlockMarkup {
+    // TODO (mani) - do code blocks have formatting?
+    // TODO (mani) - indentation for codeblocks?
+    Markdown.CodeBlock(getTextContent())
+  }
+}
+
+extension Lexical.LineBreakNode: NodeMarkdownInlineSupport {
+  public func exportInlineMarkdown(indentation: Int) throws -> Markdown.InlineMarkup {
+    Markdown.LineBreak()
+  }
+}
+
+extension Lexical.QuoteNode: NodeMarkdownBlockSupport {
+  public func exportBlockMarkdown() throws -> Markdown.BlockMarkup {
+    Markdown.BlockQuote(
+      getChildren()
+        .exportAsInlineMarkdown(indentation: getIndent())
+        .map {
+          Markdown.Paragraph($0)
+        }
+    )
+  }
+}
+
+extension Lexical.HeadingNode: NodeMarkdownBlockSupport {
+  public func exportBlockMarkdown() throws -> Markdown.BlockMarkup {
+    Markdown.Heading(
+      level: getTag().intValue,
+      getChildren().exportAsInlineMarkdown(indentation: getIndent())
+    )
+  }
+}
+
+private extension HeadingTagType {
+  var intValue: Int {
+    switch self {
+    case .h1: return 1
+    case .h2: return 2
+    case .h3: return 3
+    case .h4: return 4
+    case .h5: return 5
+    }
+  }
+}

--- a/Plugins/LexicalMarkdown/LexicalMarkdownTests/LexicalMarkdownTests.swift
+++ b/Plugins/LexicalMarkdown/LexicalMarkdownTests/LexicalMarkdownTests.swift
@@ -1,9 +1,9 @@
-//
-//  LexicalMarkdownTests.swift
-//
-//
-//  Created by mani on 15/11/2023.
-//
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import Foundation
 @testable import Lexical
@@ -29,7 +29,7 @@ class LexicalMarkdownTests: XCTestCase {
   func testNodesToMarkdown() throws {
     guard let editor else { XCTFail(); return }
 
-    XCTFail("Unimplemented")
+    XCTExpectFailure("Unimplemented")
   }
 }
 

--- a/Plugins/LexicalMarkdown/LexicalMarkdownTests/LexicalMarkdownTests.swift
+++ b/Plugins/LexicalMarkdown/LexicalMarkdownTests/LexicalMarkdownTests.swift
@@ -1,0 +1,35 @@
+//
+//  LexicalMarkdownTests.swift
+//
+//
+//  Created by mani on 15/11/2023.
+//
+
+import Foundation
+@testable import Lexical
+@testable import LexicalMarkdown
+import XCTest
+
+class LexicalMarkdownTests: XCTestCase {
+  var lexicalView: LexicalView?
+  var editor: Editor? {
+    get {
+      return lexicalView?.editor
+    }
+  }
+
+  override func setUp() {
+    lexicalView = LexicalView(editorConfig: EditorConfig(theme: Theme(), plugins: []), featureFlags: FeatureFlags())
+  }
+
+  override func tearDown() {
+    lexicalView = nil
+  }
+
+  func testNodesToMarkdown() throws {
+    guard let editor else { XCTFail(); return }
+
+    XCTFail("Unimplemented")
+  }
+}
+


### PR DESCRIPTION
This is a first pass at implementing Markdown support for lexical. 

It depends on Apple's swift-markdown package. 

It needs tests and covering more edges cases (embedded lists, indentations, etc) - but is enough to get started with.

I am also working on a markdown import for our use case, which I will add to this plugin in the next day or so.