### PR TITLE
Use a single enum for TextFormatType everywhere and use set operation…

### DIFF
--- a/Lexical/Core/Constants.swift
+++ b/Lexical/Core/Constants.swift
@@ -70,14 +70,50 @@ public enum DirtyType {
   case fullReconcile
 }
 
-@objc public enum TextFormatType: Int {
-  case bold
-  case italic
-  case underline
-  case strikethrough
-  case code
-  case subScript
-  case superScript
+public struct TextFormatType: OptionSet, CaseIterable, Codable {
+  public let rawValue: UInt
+
+  public static let bold = TextFormatType(rawValue: 1 << 0)
+  public static let italic = TextFormatType(rawValue: 1 << 1)
+  public static let strikethrough = TextFormatType(rawValue: 1 << 2)
+  public static let underline = TextFormatType(rawValue: 1 << 3)
+  public static let code = TextFormatType(rawValue: 1 << 4)
+  public static let subScript = TextFormatType(rawValue: 1 << 5)
+  public static let superScript = TextFormatType(rawValue: 1 << 6)
+
+//  Not yet supported. Is here because Javacript library supports this.
+//  Once this is supported, add it to `allCases` too
+//  static let highlight = TextFormatType(rawValue: 1 << 7)
+
+  static public var allCases: [TextFormatType] {
+    [.bold, .italic, .strikethrough, .underline, .code, .subScript, .superScript]
+  }
+
+  public var description: String {
+    switch self {
+    case .bold: return "bold"
+    case .code: return "code"
+    case .italic: return "italic"
+    case .strikethrough: return "strikethrough"
+    case .subScript: return "subscript"
+    case .superScript: return "superscript"
+    case .underline: return "underline"
+    default: return ""
+    }
+  }
+
+  public init(rawValue: UInt) {
+    self.rawValue = rawValue
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    self.rawValue = try container.decode(UInt.self)
+  }
+
+  public mutating func toggle(_ value: TextFormatType) {
+    self = symmetricDifference(value)
+  }
 }
 
 enum Direction: String, Codable {

--- a/Lexical/Core/Events.swift
+++ b/Lexical/Core/Events.swift
@@ -182,7 +182,7 @@ internal func onSelectionChange(editor: Editor) {
         guard let anchorNode = try lexicalSelection.anchor.getNode() as? TextNode else { break }
         lexicalSelection.format = anchorNode.getFormat()
       case .element:
-        lexicalSelection.format = TextFormat()
+        lexicalSelection.format = TextFormatType()
       default:
         break
       }

--- a/Lexical/Core/Nodes/CodeHighlightNode.swift
+++ b/Lexical/Core/Nodes/CodeHighlightNode.swift
@@ -49,7 +49,7 @@ public class CodeHighlightNode: TextNode {
   }
 
   // Prevent formatting (bold, underline, etc)
-  override public func setFormat(format: TextFormat) throws -> CodeHighlightNode {
+  override public func setFormat(format: TextFormatType) throws -> CodeHighlightNode {
     return try self.getWritable()
   }
 }

--- a/Lexical/Core/Reconciler.swift
+++ b/Lexical/Core/Reconciler.swift
@@ -255,7 +255,9 @@ internal enum Reconciler {
       // marked text operation.
       let length = markedTextOperation.markedTextString.lengthAsNSString()
       let endPoint = Point(key: startPoint.key, offset: startPoint.offset + length, type: .text)
-      try frontend.updateNativeSelection(from: RangeSelection(anchor: startPoint, focus: endPoint, format: TextFormat()))
+      try frontend.updateNativeSelection(from: RangeSelection(anchor: startPoint,
+                                                              focus: endPoint,
+                                                              format: TextFormatType()))
       let attributedSubstring = markedTextAttributedString.attributedSubstring(from: NSRange(location: startPoint.offset, length: length))
       editor.frontend?.setMarkedTextFromReconciler(attributedSubstring, selectedRange: markedTextOperation.markedTextInternalSelection)
 

--- a/Lexical/Core/Selection/NodeSelection.swift
+++ b/Lexical/Core/Selection/NodeSelection.swift
@@ -133,7 +133,7 @@ public class NodeSelection: BaseSelection {
     }
     let anchor = Point(key: parent.getKey(), offset: nodeIndexInParent, type: .element)
     let focus = Point(key: parent.getKey(), offset: nodeIndexInParent + 1, type: .element)
-    return RangeSelection(anchor: anchor, focus: focus, format: TextFormat())
+    return RangeSelection(anchor: anchor, focus: focus, format: TextFormatType())
   }
 }
 

--- a/Lexical/Core/Selection/RangeSelection.swift
+++ b/Lexical/Core/Selection/RangeSelection.swift
@@ -13,12 +13,12 @@ public class RangeSelection: BaseSelection {
   public var anchor: Point
   public var focus: Point
   public var dirty: Bool
-  public var format: TextFormat
+  public var format: TextFormatType
   public var style: String // TODO: add style support to iOS
 
   // MARK: - Init
 
-  public init(anchor: Point, focus: Point, format: TextFormat) {
+  public init(anchor: Point, focus: Point, format: TextFormatType) {
     self.anchor = anchor
     self.focus = focus
     self.dirty = false
@@ -40,7 +40,7 @@ public class RangeSelection: BaseSelection {
   }
 
   public func hasFormat(type: TextFormatType) -> Bool {
-    return format.isTypeSet(type: type)
+    return format.contains(type)
   }
 
   public func getCharacterOffsets(selection: RangeSelection) -> (Int, Int) {
@@ -1070,7 +1070,7 @@ public class RangeSelection: BaseSelection {
     self.anchor = anchor
     self.focus = focus
     self.dirty = false
-    self.format = TextFormat()
+    self.format = TextFormatType()
     self.style = ""
   }
 
@@ -1083,7 +1083,7 @@ public class RangeSelection: BaseSelection {
     let selectedNodes = try getNodes()
     guard var firstNode = selectedNodes.first, let lastNode = selectedNodes.last else { return }
 
-    var firstNextFormat = TextFormat()
+    var firstNextFormat = TextFormatType()
     for node in selectedNodes {
       if let node = node as? TextNode {
         firstNextFormat = node.getFormatFlags(type: formatType)
@@ -1218,12 +1218,12 @@ public class RangeSelection: BaseSelection {
   }
 
   internal func clearFormat() {
-    format = TextFormat()
+    format = TextFormatType()
   }
 
   // MARK: - Private
 
-  private func updateSelection(anchor: Point, focus: Point, format: TextFormat, isDirty: Bool) {
+  private func updateSelection(anchor: Point, focus: Point, format: TextFormatType, isDirty: Bool) {
     self.anchor.updatePoint(key: anchor.key, offset: anchor.offset, type: anchor.type)
     self.focus.updatePoint(key: focus.key, offset: focus.offset, type: focus.type)
     self.format = format

--- a/Lexical/Core/Selection/SelectionUtils.swift
+++ b/Lexical/Core/Selection/SelectionUtils.swift
@@ -234,7 +234,7 @@ func createEmptyRangeSelection() -> RangeSelection {
   let anchor = Point(key: kRootNodeKey, offset: 0, type: .element)
   let focus = Point(key: kRootNodeKey, offset: 0, type: .element)
 
-  return RangeSelection(anchor: anchor, focus: focus, format: TextFormat())
+  return RangeSelection(anchor: anchor, focus: focus, format: TextFormatType())
 }
 
 /// When we create a selection, we try to use the previous selection where possible, unless an actual user selection change has occurred.
@@ -259,7 +259,7 @@ func createSelection(editor: Editor) throws -> BaseSelection? {
 
     if let anchor = try pointAtStringLocation(range.location, searchDirection: nativeSelection.affinity, rangeCache: editor.rangeCache),
        let focus = try pointAtStringLocation(range.location + range.length, searchDirection: nativeSelection.affinity, rangeCache: editor.rangeCache) {
-      return RangeSelection(anchor: anchor, focus: focus, format: TextFormat())
+      return RangeSelection(anchor: anchor, focus: focus, format: TextFormatType())
     }
 
     return nil
@@ -285,7 +285,7 @@ func makeRangeSelection(
   let selection = RangeSelection(
     anchor: Point(key: anchorKey, offset: anchorOffset, type: anchorType),
     focus: Point(key: focusKey, offset: focusOffset, type: focusType),
-    format: TextFormat())
+    format: TextFormatType())
 
   selection.dirty = true
   editorState.selection = selection
@@ -434,7 +434,10 @@ func moveSelectionPointToEnd(point: Point, node: Node) {
   }
 }
 
-func transferStartingElementPointToTextPoint(start: Point, end: Point, format: TextFormat, style: String) throws {
+func transferStartingElementPointToTextPoint(start: Point, 
+                                             end: Point,
+                                             format: TextFormatType,
+                                             style: String) throws {
   guard let element = try start.getNode() as? ElementNode else { return }
 
   var placementNode = element.getChildAtIndex(index: start.offset)

--- a/Lexical/Core/Utils.swift
+++ b/Lexical/Core/Utils.swift
@@ -138,32 +138,14 @@ public func createCodeHighlightNode(text: String, highlightType: String?) -> Cod
   CodeHighlightNode(text: text, highlightType: highlightType)
 }
 
-public func toggleTextFormatType(format: TextFormat, type: TextFormatType, alignWithFormat: TextFormat?) -> TextFormat {
-  var activeFormat = format
-  let isStateFlagPresent = format.isTypeSet(type: type)
-  var flag = false
-
-  if let alignWithFormat {
-    // remove the type from format
-    if isStateFlagPresent && !alignWithFormat.isTypeSet(type: type) {
-      flag = false
-    }
-
-    // add the type to format
-    if alignWithFormat.isTypeSet(type: type) {
-      flag = true
-    }
+public func toggleTextFormatType(format: TextFormatType,
+                                 type: TextFormatType,
+                                 alignWithFormat: TextFormatType?) -> TextFormatType {
+  if let alignWithFormat = alignWithFormat {
+    return alignWithFormat.contains(type) ? format.union(type) : format.subtracting(type)
   } else {
-    if isStateFlagPresent {
-      flag = false
-    } else {
-      flag = true
-    }
+    return format.symmetricDifference(type)
   }
-
-  activeFormat.updateFormat(type: type, value: flag)
-
-  return activeFormat
 }
 
 public func isElementNode(node: Node?) -> Bool {

--- a/Lexical/Helper/CopyPasteHelpers.swift
+++ b/Lexical/Helper/CopyPasteHelpers.swift
@@ -126,23 +126,23 @@ internal func insertRTF(selection: RangeSelection, attributedString: NSAttribute
 
       if (attribute.attributes.first(where: { $0.key == .font })?.value as? UIFont)?
           .fontDescriptor.symbolicTraits.contains(.traitBold) ?? false {
-        textNode.format.bold = true
+        textNode.format.insert(.bold)
       }
 
       if (attribute.attributes.first(where: { $0.key == .font })?.value as? UIFont)?
           .fontDescriptor.symbolicTraits.contains(.traitItalic) ?? false {
-        textNode.format.italic = true
+        textNode.format.insert(.italic)
       }
 
       if let underlineAttribute = attribute.attributes[.underlineStyle] {
         if underlineAttribute as? NSNumber != 0 {
-          textNode.format.underline = true
+          textNode.format.insert(.underline)
         }
       }
 
       if let strikethroughAttribute = attribute.attributes[.strikethroughStyle] {
         if strikethroughAttribute as? NSNumber != 0 {
-          textNode.format.strikethrough = true
+          textNode.format.insert(.strikethrough)
         }
       }
 

--- a/Lexical/TextView/TextView.swift
+++ b/Lexical/TextView/TextView.swift
@@ -282,12 +282,16 @@ protocol LexicalTextViewDelegate: NSObjectProtocol {
       // find all nodes in selection. Mark dirty. Reconcile. This should correct all the attributes to be what we expect.
       do {
         try editor.update {
-          guard let anchor = try pointAtStringLocation(previousMarkedRange.location, searchDirection: .forward, rangeCache: editor.rangeCache),
-                let focus = try pointAtStringLocation(previousMarkedRange.location + previousMarkedRange.length, searchDirection: .forward, rangeCache: editor.rangeCache) else {
+          guard let anchor = try pointAtStringLocation(previousMarkedRange.location,
+                                                       searchDirection: .forward,
+                                                       rangeCache: editor.rangeCache),
+                let focus = try pointAtStringLocation(previousMarkedRange.location + previousMarkedRange.length, 
+                                                      searchDirection: .forward,
+                                                      rangeCache: editor.rangeCache) else {
             return
           }
 
-          let markedRangeSelection = RangeSelection(anchor: anchor, focus: focus, format: TextFormat())
+          let markedRangeSelection = RangeSelection(anchor: anchor, focus: focus, format: TextFormatType())
           _ = try markedRangeSelection.getNodes().map { node in
             internallyMarkNodeAsDirty(node: node, cause: .userInitiated)
           }


### PR DESCRIPTION
I was getting confused with having multiple types for TextFormat and having to convert between them. So i refactored to use a single TextFormatType as an OptionSet and using set operations where possible. 

Happy to discuss. Just trying to reduce the number of types lexical declares and converting between them.