### PR TITLE
Changed Theme for playground app

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-cmark.git",
+      "state" : {
+        "branch" : "gfm",
+        "revision" : "2c47322cb32cbed555f13bf5cbfaa488cc30a785"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-markdown.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "907674c2ae2d24c32fba50101821b1a7fdd291e2"
+      }
+    },
+    {
+      "identity" : "swiftsoup",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scinfu/SwiftSoup.git",
+      "state" : {
+        "revision" : "028487d4a8a291b2fe1b4392b5425b6172056148",
+        "version" : "2.7.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Playground/LexicalPlayground.xcodeproj/project.pbxproj
+++ b/Playground/LexicalPlayground.xcodeproj/project.pbxproj
@@ -450,9 +450,9 @@
 			productName = LexicalInlineImagePlugin;
 		};
 		3C48FEE32B04F2C5009BBFA2 /* LexicalMarkdown */ = {
- 			isa = XCSwiftPackageProductDependency;
- 			productName = LexicalMarkdown;
- 		};
+			isa = XCSwiftPackageProductDependency;
+			productName = LexicalMarkdown;
+		};
 /* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 0656CF6D29D1E438009CA08F /* Project object */;

--- a/Playground/LexicalPlayground/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Playground/LexicalPlayground/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,10 @@
 {
   "colors" : [
     {
+      "color" : {
+        "platform" : "universal",
+        "reference" : "systemRedColor"
+      },
       "idiom" : "universal"
     }
   ],

--- a/Playground/LexicalPlayground/ToolbarPlugin.swift
+++ b/Playground/LexicalPlayground/ToolbarPlugin.swift
@@ -140,7 +140,17 @@ public class ToolbarPlugin: Plugin {
     let insertImage = UIBarButtonItem(image: UIImage(systemName: "photo"), menu: self.imageMenu)
     self.insertImageButton = insertImage
 
-    toolbar.items = [undo, redo, paragraph, styling, link, decreaseIndent, increaseIndent, insertImage]
+    let spacer = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+      
+    toolbar.items = [undo, spacer,
+                     redo, spacer,
+                     paragraph, spacer,
+                     styling, spacer,
+                     link, spacer,
+                     decreaseIndent, spacer,
+                     increaseIndent, spacer,
+                     insertImage]
+      toolbar.barTintColor = .systemGray5
   }
 
   private enum ParagraphMenuSelectedItemType {

--- a/Playground/LexicalPlayground/ViewController.swift
+++ b/Playground/LexicalPlayground/ViewController.swift
@@ -39,7 +39,10 @@ class ViewController: UIViewController, UIToolbarDelegate {
     let theme = Theme()
     theme.indentSize = 40.0
     theme.link = [
-      .foregroundColor: UIColor.systemBlue,
+      .foregroundColor: UIColor.link,
+    ]
+    theme.code = [
+      .font: UIFont.monospacedSystemFont(ofSize: 16.0, weight: .regular),
     ]
 
     let editorConfig = EditorConfig(theme: theme, plugins: [toolbarPlugin, listPlugin, hierarchyPlugin, imagePlugin, linkPlugin, editorHistoryPlugin])
@@ -76,6 +79,9 @@ class ViewController: UIViewController, UIToolbarDelegate {
                                  y: toolbar.frame.maxY,
                                  width: view.bounds.width,
                                  height: view.bounds.height - toolbar.frame.maxY - safeAreaInsets.bottom - hierarchyViewHeight)
+        
+      lexicalView.textViewBackgroundColor = .systemGray6
+        
       hierarchyView.frame = CGRect(x: 0,
                                    y: lexicalView.frame.maxY,
                                    width: view.bounds.width,


### PR DESCRIPTION
Addresses issue #11

- Made toolbar buttons evenly spaced.
- Changed the LexicalView's TextView background color to systemGray6 (a very light gray).
- Changed the toolbar tint color to systemGray5 (a bit darker than systemGray6).
- Restyled the "code" NodeType to use a monospaced font.
- Changed playground app accent color to systemRed.