### PR TITLE
Fix quote block indentation bug by accumulating indent values

### DIFF
--- a/Lexical/Helper/AttributesUtils.swift
+++ b/Lexical/Helper/AttributesUtils.swift
@@ -105,17 +105,23 @@ enum AttributeUtils {
   ) -> [[NSAttributedString.Key: Any]] {
     var node = node
     var attributes = [[NSAttributedString.Key: Any]]()
+    var totalIndent = 0
+
     attributes.append(node.getAttributedStringAttributes(theme: theme))
     if let elementNode = node as? ElementNode, elementNode.isInline() == false {
-      attributes.append([.indent_internal: elementNode.getIndent()])
+      totalIndent += elementNode.getIndent()
     }
 
     while let parent = node.parent, let parentNode = state.nodeMap[parent] {
       attributes.append(parentNode.getAttributedStringAttributes(theme: theme))
       if let elementNode = parentNode as? ElementNode, elementNode.isInline() == false {
-        attributes.append([.indent_internal: elementNode.getIndent()])
+        totalIndent += elementNode.getIndent()
       }
       node = parentNode
+    }
+
+    if totalIndent > 0 {
+      attributes.append([.indent_internal: totalIndent])
     }
 
     return attributes

--- a/LexicalTests/Tests/AttributesUtilsTests.swift
+++ b/LexicalTests/Tests/AttributesUtilsTests.swift
@@ -441,6 +441,55 @@ class AttributesUtilsTests: XCTestCase {
     }
   }
 
+  func testParagraphInsideQuoteRetainsIndent() throws {
+    // Regression test: a ParagraphNode inside a QuoteNode should inherit the
+    // quote's indent (getIndent() == 1) so that text is offset from the quote
+    // bar. Previously, ParagraphNode's indent value of 0 overwrote QuoteNode's
+    // indent of 1 during attribute merging, leaving headIndent at zero.
+    let view = LexicalView(editorConfig: EditorConfig(theme: Theme(), plugins: []), featureFlags: FeatureFlags())
+    let editor = view.editor
+
+    try editor.update {
+      let textNode = TextNode()
+      try textNode.setText("quoted text")
+
+      let paragraphNode = ParagraphNode()
+      try paragraphNode.append([textNode])
+
+      let quoteNode = QuoteNode()
+      try quoteNode.append([paragraphNode])
+
+      guard let editorState = getActiveEditorState(),
+        let rootNode: RootNode = try editorState.getRootNode()?.getWritable()
+      else {
+        XCTFail("should have editor state")
+        return
+      }
+
+      try rootNode.getChildren().forEach { try $0.remove() }
+      try rootNode.append([quoteNode])
+
+      let combinedAttributes = AttributeUtils.attributedStringStyles(
+        from: textNode,
+        state: editorState,
+        theme: editor.getTheme()
+      )
+
+      let paragraphStyle = combinedAttributes[.paragraphStyle] as? NSParagraphStyle
+      XCTAssertNotNil(paragraphStyle, "Expected a paragraph style to be present")
+      XCTAssertEqual(
+        paragraphStyle?.headIndent,
+        CGFloat(editor.getTheme().indentSize),
+        "ParagraphNode inside QuoteNode should have headIndent equal to indentSize"
+      )
+      XCTAssertEqual(
+        paragraphStyle?.firstLineHeadIndent,
+        CGFloat(editor.getTheme().indentSize),
+        "ParagraphNode inside QuoteNode should have firstLineHeadIndent equal to indentSize"
+      )
+    }
+  }
+
   func testBlockLevelAttributesEmptyParagraphEndOfDocument() throws {
     let view = LexicalView(editorConfig: EditorConfig(theme: themeForBlockTests(), plugins: []), featureFlags: FeatureFlags())
     let editor = view.editor


### PR DESCRIPTION
Instead of appending a separate indent attribute for each block-level ancestor, accumulate all indent values into a single totalIndent and emit one .indent_internal attribute. This prevents child node indent values (e.g. ParagraphNode's 0) from overwriting parent indent values (e.g. QuoteNode's 1) during attribute merging.

Adds regression test testParagraphInsideQuoteRetainsIndent verifying that text inside a QuoteNode receives the correct headIndent and firstLineHeadIndent from the quote's indent level.

This brings the quote node behavior of lexical-ios to match the behavior of lexical web.