### PR TITLE
Register CodeNode and LineBreakNode by default; decode CodeNode language leniently

### DIFF
--- a/Lexical/Core/Editor.swift
+++ b/Lexical/Core/Editor.swift
@@ -93,7 +93,7 @@ public class Editor: NSObject {
 
   // Used for deserialization and registration of nodes. Lexical's built-in nodes are registered
   // by default.
-  internal var registeredNodes: [NodeType: Node.Type] = [.root: RootNode.self, .text: TextNode.self, .element: ElementNode.self, .heading: HeadingNode.self, .paragraph: ParagraphNode.self, .quote: QuoteNode.self]
+  internal var registeredNodes: [NodeType: Node.Type] = [.root: RootNode.self, .text: TextNode.self, .element: ElementNode.self, .heading: HeadingNode.self, .paragraph: ParagraphNode.self, .quote: QuoteNode.self, .code: CodeNode.self, .linebreak: LineBreakNode.self]
 
   internal var nodeTransforms: [NodeType: [(Int, NodeTransform)]] = [:]
 

--- a/Lexical/Core/Nodes/CodeNode.swift
+++ b/Lexical/Core/Nodes/CodeNode.swift
@@ -53,7 +53,9 @@ public class CodeNode: ElementNode {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     try super.init(from: decoder)
 
-    self.language = try container.decode(String.self, forKey: .language)
+    // Lenient: web Lexical omits `language` when none is set, so treat a
+    // missing key as an empty language rather than failing to decode.
+    self.language = try container.decodeIfPresent(String.self, forKey: .language) ?? ""
   }
 
   override public class func getType() -> NodeType {


### PR DESCRIPTION
Two fixes that allow editor states containing code blocks to round-trip through EditorState.fromJSON:

  - CodeNode and LineBreakNode are built-in node types with public NodeTypes and full rendering support, but neither was present in Editor's default registeredNodes map. As a result, deserializing any editor state that contains a code block (or a bare line break) could not reconstruct those nodes. Register them alongside the other built-ins (root, text, element, heading, paragraph, quote).
  - CodeNode's Decodable init required a "language" key. Editor states produced by other Lexical implementations (e.g. lexical-web) omit "language" when no language is set, so decoding threw keyNotFound. Use decodeIfPresent with an empty-string default so a missing language is tolerated.